### PR TITLE
Add solarwinds to root group, enable support for default statsd task (AO-12153)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN \
   curl -L https://packagecloud.io/solarwinds/${swisnap_repo}/gpgkey | apt-key add - && \
   apt-get update && \
   apt-get -y install solarwinds-snap-agent && \
+  usermod -aG root solarwinds && \
   apt-get -y purge curl python && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG="1.0.1"
+TAG="1.1.0"
 USER="solarwinds"
 REPOSITORY="solarwinds-snap-agent-docker"
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG="1.0.0"
+TAG="1.0.1"
 USER="solarwinds"
 REPOSITORY="solarwinds-snap-agent-docker"
 
@@ -6,5 +6,5 @@ build-and-release-docker:
 	@docker build -t $(USER)/$(REPOSITORY):$(TAG) .
 	@docker push $(USER)/$(REPOSITORY):$(TAG)
 
-build-test-container:
+test:
 	@docker build -t $(USER)/$(REPOSITORY):$(TAG) --build-arg swisnap_repo=swisnap-stg .

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Enable the Docker plugin in the AppOptics UI and you should start seeing data tr
 
 #### Docker
 
-If you wanted to run containerized SolarWinds Agent with custom taskfiles, you can use following snippets:
+If you wanted to run containerized SolarWinds Snap Agent with custom taskfiles, you can use following snippets:
 
 ```shell
 docker run -d -e APPOPTICS_TOKEN=token \

--- a/README.md
+++ b/README.md
@@ -41,6 +41,34 @@ Enable the Docker plugin in the AppOptics UI and you should start seeing data tr
 
 ### Sidecar
 
+#### Docker
+
+If you wanted to run containerized SolarWinds Agent with custom taskfiles, you can use following snippets:
+
+```shell
+docker run -d -e APPOPTICS_TOKEN=token \
+           -v my_custom_statsd.yaml:/opt/SolarWinds/Snap/etc/plugins.d/statsd.yaml \
+           --name swisnap-agent
+           solarwinds/solarwinds-snap-agent-docker:1.1.0
+```
+
+or using docker-compose:
+
+```yaml
+version: '3'
+services:
+  swisnap:
+    image: solarwinds/solarwinds-snap-agent-docker:1.1.0
+    hostname: swisnap-agent
+    container_name: swisnap-agent
+    volumes:
+      - /path/to/my_custom_statsd.yaml:/opt/SolarWinds/Snap/etc/plugins.d/statsd.yaml
+    environment:
+      - APPOPTICS_TOKEN=token
+```
+
+#### Kubernetes
+
 If you wanted to run this on Kubernetes as a sidecar for monitoring specific services, you can follow the instructions below which use Zookeeper as an example.
 
 Add a second container to your deployment YAML underneath `spec.template.spec.containers` and the agent should now have access to your service over `localhost`:

--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ The following environment parameters are available:
 
  Parameter                      | Description
 --------------------------------|---------------------
+ APPOPTICS_CUSTOM_TAGS          | Set this to a comma separated K=V list to enable custom tags eg. `NAME=TEST,IS_PRODUCTION=false,VERSION=5`
  APPOPTICS_TOKEN                | Your AppOptics token. This parameter is required.
- LOG_LEVEL                      | Expected value: DEBUG, INFO, WARN, ERROR or FATAL. Default value is WARN.
  APPOPTICS_HOSTNAME             | This value overrides the hostname tagged for default host metrics. The DaemonSet uses this to override with Node name.
+ LOG_LEVEL                      | Expected value: DEBUG, INFO, WARN, ERROR or FATAL. Default value is WARN.
+ SWISNAP_DISABLE_HOSTAGENT      | Set this to `true` to disable the Host Agent system metrics collection.
  SWISNAP_ENABLE_DOCKER          | Set this to `true` to enable the Docker plugin.
  SWISNAP_ENABLE_APACHE          | Set this to `true` to enable the Apache plugin.
  SWISNAP_ENABLE_ELASTICSEARCH   | Set this to `true` to enable the Elasticsearch plugin.
@@ -122,10 +124,9 @@ The following environment parameters are available:
  SWISNAP_ENABLE_MESOS           | Set this to `true` to enable the Mesos plugin.
  SWISNAP_ENABLE_MONGODB         | Set this to `true` to enable the MongoDB plugin.
  SWISNAP_ENABLE_RABBITMQ        | Set this to `true` to enable the RabbitMQ plugin.
- SWISNAP_DISABLE_HOSTAGENT      | Set this to `true` to disable the Host Agent system metrics collection.
+ SWISNAP_ENABLE_STATSD          | Set this to `true` to enable the Statsd plugin.
  SWISNAP_ENABLE_ZOOKEEPER       | Set this to `true` to enable the Zookeeper plugin.
  SWISNAP_ENABLE_MYSQL           | Set this to `true` to enable the MySQL plugin. If enabled the following ENV vars are required to be set as well: MYSQL_USER, MYSQL_PASS, MYSQL_HOST & MYSQL_PORT
- APPOPTICS_CUSTOM_TAGS          | Set this to a comma separated K=V list to enable custom tags eg. `NAME=TEST,IS_PRODUCTION=false,VERSION=5`
 
 If you use `SWISNAP_ENABLE_<plugin_name>` set to `true`, then keep in mind that AppOptics Host Agent will use default plugins configs and task manifests. For custom configuration see [Custom plugins configuration and tasks manifests](###custom-plugins-configuration-and-tasks-manifests).
 

--- a/conf/swisnap-init.sh
+++ b/conf/swisnap-init.sh
@@ -79,6 +79,10 @@ if [ "$SWISNAP_ENABLE_RABBITMQ" = "true" ]; then
     mv ${PLUGINS_DIR}/rabbitmq.yaml.example ${PLUGINS_DIR}/rabbitmq.yaml
 fi
 
+if [ "$SWISNAP_ENABLE_STATSD" = "true" ]; then
+    mv ${PLUGINS_DIR}/statsd.yaml.example ${PLUGINS_DIR}/statsd.yaml
+fi
+
 if [ "$SWISNAP_ENABLE_ZOOKEEPER" = "true" ]; then
     mv ${PLUGINS_DIR}/zookeeper.yaml.example ${PLUGINS_DIR}/zookeeper.yaml
 fi

--- a/swisnap-agent-daemonset.yaml
+++ b/swisnap-agent-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: swisnap-agent-ds
-        image: 'solarwinds/solarwinds-snap-agent-docker:1.0.1'
+        image: 'solarwinds/solarwinds-snap-agent-docker:1.1.0'
         imagePullPolicy: Always
         env:
           - name: APPOPTICS_TOKEN

--- a/swisnap-agent-daemonset.yaml
+++ b/swisnap-agent-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: swisnap-agent-ds
-        image: 'solarwinds/solarwinds-snap-agent-docker:1.0.0'
+        image: 'solarwinds/solarwinds-snap-agent-docker:1.0.1'
         imagePullPolicy: Always
         env:
           - name: APPOPTICS_TOKEN
@@ -43,6 +43,8 @@ spec:
           - name: SWISNAP_ENABLE_MYSQL
             value: 'false'
           - name: SWISNAP_ENABLE_RABBITMQ
+            value: 'false'
+          - name: SWISNAP_ENABLE_STATSD
             value: 'false'
           - name: SWISNAP_ENABLE_ZOOKEEPER
             value: 'false'

--- a/swisnap-agent-deployment.yaml
+++ b/swisnap-agent-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: swisnap-agent-serviceaccount
       containers:
         - name: swisnap-agent-k8s
-          image: 'solarwinds/solarwinds-snap-agent-docker:1.0.0'
+          image: 'solarwinds/solarwinds-snap-agent-docker:1.0.1'
           imagePullPolicy: Always
           env:
             - name: APPOPTICS_TOKEN
@@ -38,6 +38,8 @@ spec:
             - name: SWISNAP_ENABLE_MYSQL
               value: 'false'
             - name: SWISNAP_ENABLE_RABBITMQ
+              value: 'false'
+            - name: SWISNAP_ENABLE_STATSD
               value: 'false'
             - name: SWISNAP_ENABLE_ZOOKEEPER
               value: 'false'

--- a/swisnap-agent-deployment.yaml
+++ b/swisnap-agent-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: swisnap-agent-serviceaccount
       containers:
         - name: swisnap-agent-k8s
-          image: 'solarwinds/solarwinds-snap-agent-docker:1.0.1'
+          image: 'solarwinds/solarwinds-snap-agent-docker:1.1.0'
           imagePullPolicy: Always
           env:
             - name: APPOPTICS_TOKEN


### PR DESCRIPTION
With this changeset users will be able to load custom taskfiles with docker:
```shell
docker run -d -e APPOPTICS_TOKEN="<token>" \
           -v my_statsd.yaml:/opt/SolarWinds/Snap/etc/plugins.d/statsd.yaml \
           solarwinds/solarwinds-snap-agent-docker:1.0.1
```

https://swicloud.atlassian.net/browse/AO-12153