### PR TITLE
use the current deployment api version

### DIFF
--- a/swisnap-agent-deployment-event-collector.yaml
+++ b/swisnap-agent-deployment-event-collector.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: swisnap-agent-k8s-event-collector
   namespace: kube-system

--- a/swisnap-agent-deployment.yaml
+++ b/swisnap-agent-deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: swisnap-agent-k8s
   namespace: kube-system


### PR DESCRIPTION
v1beta2 for deployments has been [deprecated](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).