### PR TITLE
OA-24 ConfigMap version

### DIFF
--- a/conf/swisnap-init.sh
+++ b/conf/swisnap-init.sh
@@ -110,8 +110,6 @@ main() {
     run_plugins_with_default_configs
     set_custom_tags
 
-    env | sort
-
     # shellcheck disable=SC2086
     exec ${SWISNAP_HOME}/sbin/swisnapd --config ${CONFIG_FILE} ${FLAGS} --log-path ""
 }

--- a/conf/swisnap-init.sh
+++ b/conf/swisnap-init.sh
@@ -110,6 +110,8 @@ main() {
     run_plugins_with_default_configs
     set_custom_tags
 
+    env | sort
+
     # shellcheck disable=SC2086
     exec ${SWISNAP_HOME}/sbin/swisnapd --config ${CONFIG_FILE} ${FLAGS} --log-path ""
 }

--- a/deploy/base/daemonset/kustomization.yaml
+++ b/deploy/base/daemonset/kustomization.yaml
@@ -7,5 +7,25 @@ commonLabels:
   part-of: monitoring
   component: agent
 
+configMapGenerator:
+  - name: swisnap-host-configmap
+    behavior: create
+    literals:
+      - SWISNAP_ENABLE_APACHE=false
+      - SWISNAP_ENABLE_DOCKER=true
+      - SWISNAP_ENABLE_ELASTICSEARCH=false
+      - SWISNAP_ENABLE_KUBERNETES=true
+      - SWISNAP_ENABLE_MESOS=false
+      - SWISNAP_ENABLE_MONGODB=false
+      - SWISNAP_ENABLE_MYSQL=false
+      - SWISNAP_ENABLE_RABBITMQ=false
+      - SWISNAP_ENABLE_STATSD=false
+      - SWISNAP_ENABLE_ZOOKEEPER=false
+      - SWISNAP_DISABLE_HOSTAGENT=false
+      - SWISNAP_DISABLE_PROCESSES=false
+      - SWISNAP_SECURE=false
+      - HOST_PROC=/host/proc
+      - LOG_LEVEL=INFO
+
 resources:
   - swisnap-agent-daemonset.yaml

--- a/deploy/base/daemonset/swisnap-agent-daemonset.yaml
+++ b/deploy/base/daemonset/swisnap-agent-daemonset.yaml
@@ -37,32 +37,9 @@ spec:
               secretKeyRef:
                 name: appoptics-token
                 key: APPOPTICS_TOKEN
-          - name: SWISNAP_ENABLE_APACHE
-            value: "false"
-          - name: SWISNAP_ENABLE_DOCKER
-            value: "true"
-          - name: SWISNAP_ENABLE_ELASTICSEARCH
-            value: "false"
-          - name: SWISNAP_ENABLE_KUBERNETES
-            value: "false"
-          - name: SWISNAP_ENABLE_MESOS
-            value: "false"
-          - name: SWISNAP_ENABLE_MONGODB
-            value: "false"
-          - name: SWISNAP_ENABLE_MYSQL
-            value: "false"
-          - name: SWISNAP_ENABLE_RABBITMQ
-            value: "false"
-          - name: SWISNAP_ENABLE_STATSD
-            value: "false"
-          - name: SWISNAP_ENABLE_ZOOKEEPER
-            value: "false"
-          - name: SWISNAP_DISABLE_HOSTAGENT
-            value: "false"
-          - name: SWISNAP_DISABLE_PROCESSES
-            value: "false"
-          - name: SWISNAP_SECURE
-            value: "false"    
+        envFrom:
+          - configMapRef:
+              name: swisnap-host-configmap   
         volumeMounts:
           - name: docker-sock
             mountPath: /var/run/docker.sock

--- a/deploy/base/deployment/kustomization.yaml
+++ b/deploy/base/deployment/kustomization.yaml
@@ -7,6 +7,26 @@ commonLabels:
   part-of: monitoring
   component: agent
 
+configMapGenerator:
+  - name: swisnap-k8s-configmap
+    behavior: create
+    literals:
+      - SWISNAP_ENABLE_APACHE=false
+      - SWISNAP_ENABLE_DOCKER=false
+      - SWISNAP_ENABLE_ELASTICSEARCH=false
+      - SWISNAP_ENABLE_KUBERNETES=true
+      - SWISNAP_ENABLE_MESOS=false
+      - SWISNAP_ENABLE_MONGODB=false
+      - SWISNAP_ENABLE_MYSQL=false
+      - SWISNAP_ENABLE_RABBITMQ=false
+      - SWISNAP_ENABLE_STATSD=false
+      - SWISNAP_ENABLE_ZOOKEEPER=false
+      - SWISNAP_DISABLE_HOSTAGENT=true
+      - SWISNAP_DISABLE_PROCESSES=true
+      - SWISNAP_SECURE=false
+      - HOST_PROC=/host/proc
+      - LOG_LEVEL=INFO
+
 resources:
   - swisnap-agent-deployment.yaml
   - swisnap-agent-serviceaccount.yaml

--- a/deploy/base/deployment/swisnap-agent-deployment.yaml
+++ b/deploy/base/deployment/swisnap-agent-deployment.yaml
@@ -41,34 +41,9 @@ spec:
                 secretKeyRef:
                   name: appoptics-token
                   key: APPOPTICS_TOKEN
-            - name: LOG_LEVEL
-              value: "WARN"
-            - name: SWISNAP_ENABLE_APACHE
-              value: "false"
-            - name: SWISNAP_ENABLE_DOCKER
-              value: "false"
-            - name: SWISNAP_ENABLE_ELASTICSEARCH
-              value: "false"
-            - name: SWISNAP_ENABLE_KUBERNETES
-              value: "true"
-            - name: SWISNAP_ENABLE_MESOS
-              value: "false"
-            - name: SWISNAP_ENABLE_MONGODB
-              value: "false"
-            - name: SWISNAP_ENABLE_MYSQL
-              value: "false"
-            - name: SWISNAP_ENABLE_RABBITMQ
-              value: "false"
-            - name: SWISNAP_ENABLE_STATSD
-              value: "false"
-            - name: SWISNAP_ENABLE_ZOOKEEPER
-              value: "false"
-            - name: SWISNAP_DISABLE_HOSTAGENT
-              value: "true"
-            - name: SWISNAP_DISABLE_PROCESSES
-              value: "true"
-            - name: SWISNAP_SECURE
-              value: "false" 
+          envFrom:
+            - configMapRef:
+                name: swisnap-k8s-configmap
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
This PR is just to show the issues when using the configmap for environment variables.

To deploy locally:
```
kubectl create secret generic appoptics-token -n kube-system --from-literal=APPOPTICS_TOKEN=<REPLACE WITH TOKEN>
make test # build image
make deploy-deployment
```

The deployment pod will come up and show running, but metrics won't be posted to appoptics and if we look at the logs we see

```
INFO[2020-05-11T09:06:29Z] pickfirstBalancer: HandleSubConnStateChange: 0xc0000a1980, TRANSIENT_FAILURE 
INFO[2020-05-11T09:06:30Z] pickfirstBalancer: HandleSubConnStateChange: 0xc0000a1980, CONNECTING 
INFO[2020-05-11T09:06:30Z] grpc: addrConn.createTransport failed to connect to {127.0.0.1:39635 0  <nil>}. Err :connection error: desc = "transport: Error while dialing dial tcp 127.0.0.1:39635: connect: connection refused". Reconnecting... 
INFO[2020-05-11T09:06:30Z] pickfirstBalancer: HandleSubConnStateChange: 0xc0000a1980, TRANSIENT_FAILURE 
WARN[2020-05-11T09:06:30Z] heartbeat missed  