### PR TITLE
Add /host/proc to volume and whitespace changes (AO-16529)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:bionic
 LABEL authors='SolarWinds AppOptics team <support@appoptics.com>'
 
 USER root
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 ARG swisnap_repo=swisnap
 RUN apt-get update && \

--- a/deploy/base/daemonset/kustomization.yaml
+++ b/deploy/base/daemonset/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace:  kube-system
+namespace: kube-system
 
 commonLabels: 
   part-of: monitoring

--- a/deploy/base/daemonset/swisnap-agent-daemonset.yaml
+++ b/deploy/base/daemonset/swisnap-agent-daemonset.yaml
@@ -39,7 +39,7 @@ spec:
                 key: APPOPTICS_TOKEN
         envFrom:
           - configMapRef:
-              name: swisnap-host-configmap   
+              name: swisnap-host-configmap
         volumeMounts:
           - name: docker-sock
             mountPath: /var/run/docker.sock

--- a/deploy/base/deployment/kustomization.yaml
+++ b/deploy/base/deployment/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace:  kube-system
+namespace: kube-system
 
 commonLabels: 
   part-of: monitoring

--- a/deploy/base/deployment/swisnap-agent-deployment.yaml
+++ b/deploy/base/deployment/swisnap-agent-deployment.yaml
@@ -44,6 +44,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: swisnap-k8s-configmap
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
           resources:
             limits:
               cpu: 100m
@@ -51,6 +55,10 @@ spec:
             requests:
               cpu: 100m
               memory: 256Mi
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
* Fixing warning during docker build (fixing typo with missing = for DEBIAN_FRONTEND https://docs.docker.com/engine/faq/#why-is-debian_frontendnoninteractive-discouraged-in-dockerfiles)
* Some whitespace changes
* add /host/proc mount for deployment (where kubernetes plugin is enabled) - due the appoptics publisher trying to open file(s) under $HOST_PROC
