### PR TITLE
Resource reqs to DS from Dep; fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker and Kubernetes assets for running SolarWinds Snap Agent
   * [About](#about)
   * [Installation](#installation)
     * [Deployment](#deployment)
-    * [DaemonSet](daemonset)
+    * [DaemonSet](#daemonset)
     * [Sidecar](#sidecar)
   * [Configuration](#configuration)
     * [Custom plugins configuration and tasks manifests](#custom-plugins-configuration-and-tasks-manifests)

--- a/deploy/base/daemonset/swisnap-agent-daemonset.yaml
+++ b/deploy/base/daemonset/swisnap-agent-daemonset.yaml
@@ -55,6 +55,13 @@ spec:
               readOnly: true
             - name: cgroup
               mountPath: /sys/fs/cgroup
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
           livenessProbe:
             httpGet:
               path: /v1/plugins


### PR DESCRIPTION
## What
* Adds resource declarations to the AO DaemonSet copied from Deployment
* Fix a link in README

## Why
Lack of these declarations was an oversight -- each should have resource requirements/limits listed.