### PR TITLE
AO-20841 Introduce CRI plugin as an option for monitoring CRI compliant engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,15 @@ Enable the Kubernetes plugin in the AppOptics UI and you should start seeing dat
 
 ### DaemonSet
 
-The DaemonSet, by default, will give you insight into [containers](https://docs.appoptics.com/kb/host_infrastructure/#list-and-map-view) running within its nodes and gather system, processes and docker-related metrics. To deploy the DaemonSet to Kubernetes verify you have an `solarwinds-token` secret already created and run:
+The DaemonSet, by default, will give you insight into [containers](https://docs.appoptics.com/kb/host_infrastructure/#list-and-map-view) running within its nodes and gather system, processes and container-related metrics. To deploy the DaemonSet to Kubernetes verify you have an `solarwinds-token` secret already created and run:
 ``` bash
 kubectl apply -k ./deploy/overlays/stable/daemonset
 ```
 
-Enable the Docker plugin in the AppOptics UI and you should start seeing data trickle in.
+Starting from version 4.5.0-* the default monitored container engine is containerd.
+Enable the CRI plugin in the AppOptics UI and you should start seeing data trickle in.
+
+To fallback to the docker plugin and docker-based metrics  
 
 ### Sidecar
 

--- a/conf/swisnap-init.sh
+++ b/conf/swisnap-init.sh
@@ -87,9 +87,6 @@ run_plugins_with_default_configs() {
         cri_plugin_config="${TASK_AUTOLOAD_DIR}/task-cri.yaml"
         if check_if_plugin_supported CRI "${cri_plugin_config}.example"; then
             mv "${cri_plugin_config}.example" "${cri_plugin_config}"
-            if [[ -n "${HOST_PROC}" ]]; then
-                sed -i 's,procfs: "/proc",procfs: "'"${HOST_PROC}"'",g' "${cri_plugin_config}"
-            fi
         fi
     fi
 

--- a/conf/swisnap-init.sh
+++ b/conf/swisnap-init.sh
@@ -83,6 +83,16 @@ run_plugins_with_default_configs() {
         fi
     fi
 
+    if [ "${SWISNAP_ENABLE_CRI}" = "true" ]; then
+        cri_plugin_config="${TASK_AUTOLOAD_DIR}/task-cri.yaml"
+        if check_if_plugin_supported CRI "${cri_plugin_config}.example"; then
+            mv "${cri_plugin_config}.example" "${cri_plugin_config}"
+            if [[ -n "${HOST_PROC}" ]]; then
+                sed -i 's,procfs: "/proc",procfs: "'"${HOST_PROC}"'",g' "${cri_plugin_config}"
+            fi
+        fi
+    fi
+
     if [ "${SWISNAP_ENABLE_DOCKER}" = "true" ]; then
         docker_plugin_config="${PLUGINS_DIR}/docker.yaml"
         if check_if_plugin_supported Docker "${docker_plugin_config}.example"; then

--- a/deploy/base/daemonset/kustomization.yaml
+++ b/deploy/base/daemonset/kustomization.yaml
@@ -13,8 +13,6 @@ configMapGenerator:
     behavior: create
     literals:
       - SWISNAP_ENABLE_APACHE=false
-      - SWISNAP_ENABLE_CRI=true
-      - SWISNAP_ENABLE_DOCKER=true
       - SWISNAP_ENABLE_ELASTICSEARCH=false
       - SWISNAP_ENABLE_KUBERNETES=false
       - SWISNAP_ENABLE_MESOS=false

--- a/deploy/base/daemonset/kustomization.yaml
+++ b/deploy/base/daemonset/kustomization.yaml
@@ -13,6 +13,7 @@ configMapGenerator:
     behavior: create
     literals:
       - SWISNAP_ENABLE_APACHE=false
+      - SWISNAP_ENABLE_CRI=true
       - SWISNAP_ENABLE_DOCKER=true
       - SWISNAP_ENABLE_ELASTICSEARCH=false
       - SWISNAP_ENABLE_KUBERNETES=false

--- a/deploy/base/daemonset/swisnap-agent-daemonset.yaml
+++ b/deploy/base/daemonset/swisnap-agent-daemonset.yaml
@@ -101,12 +101,6 @@ spec:
             initialDelaySeconds: 10
             timeoutSeconds: 5
       volumes:
-        - name: docker-sock
-          hostPath:
-            path: /var/run/docker.sock
-        - name: dockershim-sock
-          hostPath:
-            path: /var/run/dockershim.sock
         - name: proc
           hostPath:
             path: /proc

--- a/deploy/base/daemonset/swisnap-agent-daemonset.yaml
+++ b/deploy/base/daemonset/swisnap-agent-daemonset.yaml
@@ -72,10 +72,6 @@ spec:
             - configMapRef:
                 name: swisnap-host-configmap
           volumeMounts:
-            - name: docker-sock
-              mountPath: /var/run/docker.sock
-            - name: dockershim-sock
-              mountPath: /var/run/dockershim.sock
             - name: proc
               mountPath: /host/proc
               readOnly: true

--- a/deploy/base/daemonset/swisnap-agent-daemonset.yaml
+++ b/deploy/base/daemonset/swisnap-agent-daemonset.yaml
@@ -74,6 +74,8 @@ spec:
           volumeMounts:
             - name: docker-sock
               mountPath: /var/run/docker.sock
+            - name: dockershim-sock
+              mountPath: /var/run/dockershim.sock
             - name: proc
               mountPath: /host/proc
               readOnly: true
@@ -102,6 +104,9 @@ spec:
         - name: docker-sock
           hostPath:
             path: /var/run/docker.sock
+        - name: dockershim-sock
+          hostPath:
+            path: /var/run/dockershim.sock
         - name: proc
           hostPath:
             path: /proc

--- a/deploy/base/deployment/kustomization.yaml
+++ b/deploy/base/deployment/kustomization.yaml
@@ -13,6 +13,7 @@ configMapGenerator:
     behavior: create
     literals:
       - SWISNAP_ENABLE_APACHE=false
+      - SWISNAP_ENABLE_CRI=false
       - SWISNAP_ENABLE_DOCKER=false
       - SWISNAP_ENABLE_ELASTICSEARCH=false
       - SWISNAP_ENABLE_KUBERNETES=true

--- a/deploy/overlays/stable/daemonset/kustomization.yaml
+++ b/deploy/overlays/stable/daemonset/kustomization.yaml
@@ -11,6 +11,8 @@ configMapGenerator:
   - name: swisnap-host-configmap
     behavior: merge
     literals:
+      - SWISNAP_ENABLE_CRI=false
+      - SWISNAP_ENABLE_DOCKER=true
       - SWISNAP_ENABLE_DOCKER_LOGS=false
       - SWISNAP_DOCKER_LOGS_CONTAINER_NAMES=""
 
@@ -19,26 +21,5 @@ images:
     newName: swipoleszcz/swidummy
     newTag: latest
 
-spec:
-  template:
-    spec:
-      volumes:
-        - name: docker-sock
-          hostPath:
-            path: /var/run/docker.sock
-        # - name: dockershim-sock
-        #   hostPath:
-        #     path: /var/run/dockershim.sock
-        - name: containerd-sock
-          hostPath:
-            path: /run/containerd/containerd.sock
-
-      containers:
-      - name: swisnap-agent-ds
-        volumeMounts:
-          - name: docker-sock
-            mountPath: /var/run/docker.sock
-          # - name: dockershim-sock
-          #   mountPath: /var/run/dockershim.sock
-          - name: containerd-sock
-            mountPath: /run/containerd/containerd.sock
+patchesStrategicMerge:
+- patch-containers-engine.yaml

--- a/deploy/overlays/stable/daemonset/kustomization.yaml
+++ b/deploy/overlays/stable/daemonset/kustomization.yaml
@@ -35,10 +35,10 @@ spec:
 
       containers:
       - name: swisnap-agent-ds
-          volumeMounts:
-            - name: docker-sock
-              mountPath: /var/run/docker.sock
-            # - name: dockershim-sock
-            #   mountPath: /var/run/dockershim.sock
-            - name: containerd-sock
-              mountPath: /run/containerd/containerd.sock
+        volumeMounts:
+          - name: docker-sock
+            mountPath: /var/run/docker.sock
+          # - name: dockershim-sock
+          #   mountPath: /var/run/dockershim.sock
+          - name: containerd-sock
+            mountPath: /run/containerd/containerd.sock

--- a/deploy/overlays/stable/daemonset/kustomization.yaml
+++ b/deploy/overlays/stable/daemonset/kustomization.yaml
@@ -33,12 +33,12 @@ spec:
           hostPath:
             path: /run/containerd/containerd.sock
 
-    containers:
-      name: swisnap-agent-ds
-        volumeMounts:
-          - name: docker-sock
-            mountPath: /var/run/docker.sock
-          # - name: dockershim-sock
-          #   mountPath: /var/run/dockershim.sock
-          - name: containerd-sock
-            mountPath: /run/containerd/containerd.sock
+      containers:
+        name: swisnap-agent-ds
+          volumeMounts:
+            - name: docker-sock
+              mountPath: /var/run/docker.sock
+            # - name: dockershim-sock
+            #   mountPath: /var/run/dockershim.sock
+            - name: containerd-sock
+              mountPath: /run/containerd/containerd.sock

--- a/deploy/overlays/stable/daemonset/kustomization.yaml
+++ b/deploy/overlays/stable/daemonset/kustomization.yaml
@@ -15,5 +15,6 @@ configMapGenerator:
       - SWISNAP_DOCKER_LOGS_CONTAINER_NAMES=""
 
 images:
-  - name: solarwinds/solarwinds-snap-agent-docker
-    newTag: 4.4.0-4.3.0.1156
+  - name: solarwinds/solarwinds-snap-agent-docker:latest
+    newName: swipoleszcz/swidummy
+    newTag: latest

--- a/deploy/overlays/stable/daemonset/kustomization.yaml
+++ b/deploy/overlays/stable/daemonset/kustomization.yaml
@@ -17,9 +17,8 @@ configMapGenerator:
       - SWISNAP_DOCKER_LOGS_CONTAINER_NAMES=""
 
 images:
-  - name: solarwinds/solarwinds-snap-agent-docker:latest
-    newName: swipoleszcz/swidummy
-    newTag: latest
+  - name: solarwinds/solarwinds-snap-agent-docker
+    newTag: 4.4.0-4.3.0.1156
 
 patchesStrategicMerge:
 - patch-containers-engine.yaml

--- a/deploy/overlays/stable/daemonset/kustomization.yaml
+++ b/deploy/overlays/stable/daemonset/kustomization.yaml
@@ -11,8 +11,8 @@ configMapGenerator:
   - name: swisnap-host-configmap
     behavior: merge
     literals:
-      - SWISNAP_ENABLE_CRI=false
-      - SWISNAP_ENABLE_DOCKER=true
+      - SWISNAP_ENABLE_CRI=true
+      - SWISNAP_ENABLE_DOCKER=false
       - SWISNAP_ENABLE_DOCKER_LOGS=false
       - SWISNAP_DOCKER_LOGS_CONTAINER_NAMES=""
 

--- a/deploy/overlays/stable/daemonset/kustomization.yaml
+++ b/deploy/overlays/stable/daemonset/kustomization.yaml
@@ -34,7 +34,7 @@ spec:
             path: /run/containerd/containerd.sock
 
       containers:
-        name: swisnap-agent-ds
+      - name: swisnap-agent-ds
           volumeMounts:
             - name: docker-sock
               mountPath: /var/run/docker.sock

--- a/deploy/overlays/stable/daemonset/kustomization.yaml
+++ b/deploy/overlays/stable/daemonset/kustomization.yaml
@@ -18,3 +18,27 @@ images:
   - name: solarwinds/solarwinds-snap-agent-docker:latest
     newName: swipoleszcz/swidummy
     newTag: latest
+
+spec:
+  template:
+    spec:
+      volumes:
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
+        # - name: dockershim-sock
+        #   hostPath:
+        #     path: /var/run/dockershim.sock
+        - name: containerd-sock
+          hostPath:
+            path: /run/containerd/containerd.sock
+
+    containers:
+      name: swisnap-agent-ds
+        volumeMounts:
+          - name: docker-sock
+            mountPath: /var/run/docker.sock
+          # - name: dockershim-sock
+          #   mountPath: /var/run/dockershim.sock
+          - name: containerd-sock
+            mountPath: /run/containerd/containerd.sock

--- a/deploy/overlays/stable/daemonset/patch-containers-engine.yaml
+++ b/deploy/overlays/stable/daemonset/patch-containers-engine.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: swisnap-agent-ds
+spec:
+  template:
+    spec:
+      containers:
+      - name: swisnap-agent-ds
+        volumeMounts:
+          ## Docker plugin
+          - name: docker-sock
+            mountPath: /var/run/docker.sock
+          ## CRI plugin options
+          # - name: containerd-sock
+          #   mountPath: /run/containerd/containerd.sock
+          # - name: dockershim-sock
+          #   mountPath: /var/run/dockershim.sock
+          # - name: crio-sock
+          #   mountPath: /run/crio/crio.sock
+      volumes:
+        ## Docker plugin
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
+        ## CRI plugin options
+        # - name: containerd-sock
+        #   hostPath:
+        #     path: /run/containerd/containerd.sock
+        # - name: dockershim-sock
+        #   hostPath:
+        #     path: /var/run/dockershim.sock
+        # - name: crio-sock
+        #   hostPath:
+        #     path: /run/crio/crio.sock

--- a/deploy/overlays/stable/daemonset/patch-containers-engine.yaml
+++ b/deploy/overlays/stable/daemonset/patch-containers-engine.yaml
@@ -10,24 +10,24 @@ spec:
       - name: swisnap-agent-ds
         volumeMounts:
           ## Docker plugin
-          - name: docker-sock
-            mountPath: /var/run/docker.sock
+          # - name: docker-sock
+          #   mountPath: /var/run/docker.sock
           ## CRI plugin options
-          # - name: containerd-sock
-          #   mountPath: /run/containerd/containerd.sock
+          - name: containerd-sock
+            mountPath: /run/containerd/containerd.sock
           # - name: dockershim-sock
           #   mountPath: /var/run/dockershim.sock
           # - name: crio-sock
           #   mountPath: /run/crio/crio.sock
       volumes:
         ## Docker plugin
-        - name: docker-sock
-          hostPath:
-            path: /var/run/docker.sock
-        ## CRI plugin options
-        # - name: containerd-sock
+        # - name: docker-sock
         #   hostPath:
-        #     path: /run/containerd/containerd.sock
+        #     path: /var/run/docker.sock
+        ## CRI plugin options
+        - name: containerd-sock
+          hostPath:
+            path: /run/containerd/containerd.sock
         # - name: dockershim-sock
         #   hostPath:
         #     path: /var/run/dockershim.sock


### PR DESCRIPTION
I went with the simpliest and the most reliable option - leaving configuration of socket mounting to the user. I've added most expected options in the kustomize yaml.

Proposal of the documentation change:
https://swicloud.atlassian.net/wiki/spaces/~229243988/pages/2828665273/AO-20596+Doc+update+-+proposal