### PR TITLE
AO-20573 Enable swisnap cli inside of the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ USER root
 ARG DEBIAN_FRONTEND=noninteractive
 ARG swisnap_repo=swisnap
 
+ENV SNAP_URL=http://127.0.0.1:21413
+
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get -y install \

--- a/conf/swisnap-init.sh
+++ b/conf/swisnap-init.sh
@@ -9,6 +9,7 @@ CONFIG_FILE="${SWISNAP_HOME}/etc/config.yaml"
 PUBLISHER_PROCESSES_CONFIG="${PLUGINS_DIR}/publisher-processes.yaml"
 PUBLISHER_APPOPTICS_CONFIG="${PLUGINS_DIR}/publisher-appoptics.yaml"
 PUBLISHER_LOGS_CONFIG="${PLUGINS_DIR}/publisher-logs.yaml"
+API_PORT="21413"
 
 swisnap_config_setup() {
     echo "Running swisnap_config_setup"
@@ -44,7 +45,7 @@ swisnap_config_setup() {
     fi
 
     yq w -i ${CONFIG_FILE} log_path "${LOG_PATH:-/proc/self/fd/1}"
-    yq w -i ${CONFIG_FILE} restapi.addr "tcp://0.0.0.0:21413"
+    yq w -i ${CONFIG_FILE} restapi.addr "tcp://0.0.0.0:${API_PORT}"
 
     # Logs Publishers releated configs
     if [ -n "${LOGGLY_TOKEN}" ] && [ "${LOGGLY_TOKEN}" != 'LOGGLY_TOKEN' ]; then
@@ -315,11 +316,16 @@ check_if_plugin_supported() {
     return 0
 }
 
+enable_swisnap_cli() {
+    export SNAP_URL="http://127.0.0.1:${API_PORT}"
+}
+
 main() {
     swisnap_config_setup
     run_plugins_with_default_configs
     run_plugins_customizations
     set_custom_tags
+    enable_swisnap_cli
     exec "${SWISNAP_HOME}/sbin/swisnapd" --config "${CONFIG_FILE}" "${FLAGS[@]}"
 }
 

--- a/conf/swisnap-init.sh
+++ b/conf/swisnap-init.sh
@@ -9,7 +9,6 @@ CONFIG_FILE="${SWISNAP_HOME}/etc/config.yaml"
 PUBLISHER_PROCESSES_CONFIG="${PLUGINS_DIR}/publisher-processes.yaml"
 PUBLISHER_APPOPTICS_CONFIG="${PLUGINS_DIR}/publisher-appoptics.yaml"
 PUBLISHER_LOGS_CONFIG="${PLUGINS_DIR}/publisher-logs.yaml"
-API_PORT="21413"
 
 swisnap_config_setup() {
     echo "Running swisnap_config_setup"
@@ -45,7 +44,7 @@ swisnap_config_setup() {
     fi
 
     yq w -i ${CONFIG_FILE} log_path "${LOG_PATH:-/proc/self/fd/1}"
-    yq w -i ${CONFIG_FILE} restapi.addr "tcp://0.0.0.0:${API_PORT}"
+    yq w -i ${CONFIG_FILE} restapi.addr "tcp://0.0.0.0:21413"
 
     # Logs Publishers releated configs
     if [ -n "${LOGGLY_TOKEN}" ] && [ "${LOGGLY_TOKEN}" != 'LOGGLY_TOKEN' ]; then
@@ -316,16 +315,11 @@ check_if_plugin_supported() {
     return 0
 }
 
-enable_swisnap_cli() {
-    export SNAP_URL="http://127.0.0.1:${API_PORT}"
-}
-
 main() {
     swisnap_config_setup
     run_plugins_with_default_configs
     run_plugins_customizations
     set_custom_tags
-    enable_swisnap_cli
     exec "${SWISNAP_HOME}/sbin/swisnapd" --config "${CONFIG_FILE}" "${FLAGS[@]}"
 }
 


### PR DESCRIPTION
I'm not sure about the intention of task reporter. 
Dominik suggested to do it in the init script. As far as I understand it would require to extend .profile script within init script so users attaching to container later would have thin ENV in their shell (if I understand Dominik's intention well).
Having it on Dockerfile is straightforward.